### PR TITLE
Fix call to Ensure in integer specialization of std::vector.

### DIFF
--- a/include/nop/base/vector.h
+++ b/include/nop/base/vector.h
@@ -161,7 +161,7 @@ struct Encoding<std::vector<T, Allocator>, EnableIfIntegral<T>>
 
     // Make sure the reader has enough data to fulfill the requested size as a
     // defense against abusive or erroneous vector sizes.
-    status = reader->Ensure(length);
+    status = reader->Ensure(size);
     if (!status)
       return status;
 

--- a/test/serializer_tests.cpp
+++ b/test/serializer_tests.cpp
@@ -659,7 +659,9 @@ TEST(Deserializer, IntegerVectorFailOnEnsure) {
   Deserializer<MockReader*> deserializer{&reader};
   Status<void> status;
 
-  EXPECT_CALL(reader, Ensure(2))
+  std::size_t length_bytes = 2 * sizeof(std::uint16_t);
+
+  EXPECT_CALL(reader, Ensure(length_bytes))
       .Times(1)
       .WillOnce(Return(ErrorStatus::ReadLimitReached));
   EXPECT_CALL(reader, Read(_))
@@ -667,12 +669,12 @@ TEST(Deserializer, IntegerVectorFailOnEnsure) {
       .WillOnce(DoAll(
           SetArgPointee<0>(static_cast<std::uint8_t>(EncodingByte::Binary)),
           Return(Status<void>{})))
-      .WillOnce(DoAll(SetArgPointee<0>(2), Return(Status<void>{})))
+      .WillOnce(DoAll(SetArgPointee<0>(length_bytes), Return(Status<void>{})))
       .WillRepeatedly(Return(ErrorStatus::ReadLimitReached));
   EXPECT_CALL(reader, Read(_, _)).Times(0);
   EXPECT_CALL(reader, Skip(_)).Times(0);
 
-  std::vector<std::uint8_t> value;
+  std::vector<std::uint16_t> value;
   status = deserializer.Read(&value);
   EXPECT_FALSE(status);
   EXPECT_EQ(ErrorStatus::ReadLimitReached, status.error());


### PR DESCRIPTION
Ensure takes a length in bytes, not number of elements.