### PR TITLE
set, unordered_set, and deque support

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,9 +56,10 @@ This interface supports the following types:
   * enum and enum classes.
   * std::string.
   * C-style arrays with elements of any supported type.
-  * std::array, std::pair, std::tuple, and std::vector with elements of any
+  * std::array, std::pair, std::tuple, std::vector, and std::deque with elements of any
     supported type.
   * std::map and std::unordered_map with keys and values of any supported type.
+  * std::set and std::unordered_set with keys of any supported type.
   * std::reference_wrapper<T> with T of any supported type.
   * nop::Optional<T> with T of any supported type.
   * nop::Result<ErrorEnum, T> with T of any supported type.

--- a/include/nop/base/deque.h
+++ b/include/nop/base/deque.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 The Native Object Protocols Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBNOP_INCLUDE_NOP_BASE_DEQUE_H_
+#define LIBNOP_INCLUDE_NOP_BASE_DEQUE_H_
+
+#include <nop/base/encoding.h>
+#include <nop/base/utility.h>
+
+#include <deque>
+#include <numeric>
+
+namespace nop {
+
+//
+// std::deque<T> encoding format:
+//
+// +-------+---------+-----//-----+
+// | DEQUE | INT64:N | N ELEMENTS |
+// +-------+---------+-----//-----+
+//
+// Elements must be valid encodings of type T.
+//
+
+template <typename T, typename Allocator>
+struct Encoding<std::deque<T, Allocator>>
+    : EncodingIO<std::deque<T, Allocator>> {
+  using Type = std::deque<T, Allocator>;
+
+  static constexpr EncodingByte Prefix(const Type& /*value*/) {
+    return EncodingByte::Array;
+  }
+
+  static constexpr std::size_t Size(const Type& value) {
+    return BaseEncodingSize(Prefix(value)) +
+           Encoding<SizeType>::Size(value.size()) +
+           std::accumulate(value.cbegin(), value.cend(), 0U,
+                           [](const std::size_t& sum, const T& element) {
+                             return sum + Encoding<T>::Size(element);
+                           });
+  }
+
+  static constexpr bool Match(EncodingByte prefix) {
+    return prefix == EncodingByte::Array;
+  }
+
+  template <typename Writer>
+  static constexpr Status<void> WritePayload(EncodingByte /*prefix*/,
+                                             const Type& value,
+                                             Writer* writer) {
+    auto status = Encoding<SizeType>::Write(value.size(), writer);
+    if (!status)
+      return status;
+
+    for (const T& element : value) {
+      status = Encoding<T>::Write(element, writer);
+      if (!status)
+        return status;
+    }
+
+    return {};
+  }
+
+  template <typename Reader>
+  static constexpr Status<void> ReadPayload(EncodingByte /*prefix*/,
+                                            Type* value, Reader* reader) {
+    SizeType size = 0;
+    auto status = Encoding<SizeType>::Read(&size, reader);
+    if (!status)
+      return status;
+
+    value->clear();
+    for (SizeType i = 0; i < size; i++) {
+      T element;
+      status = Encoding<T>::Read(&element, reader);
+      if (!status)
+        return status;
+
+      value->push_back(std::move(element));
+    }
+
+    return {};
+  }
+};
+
+}  // namespace nop
+
+#endif  // LIBNOP_INCLUDE_NOP_BASE_DEQUE_H_

--- a/include/nop/base/set.h
+++ b/include/nop/base/set.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 The Native Object Protocols Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBNOP_INCLUDE_NOP_BASE_SET_H_
+#define LIBNOP_INCLUDE_NOP_BASE_SET_H_
+
+#include <nop/base/encoding.h>
+
+#include <numeric>
+#include <set>
+#include <unordered_set>
+
+namespace nop {
+
+//
+// std::set<Key> and std::unordered_set<Key> encoding format:
+//
+// +-----+---------+---//---+
+// | SET | INT64:N | N KEYS |
+// +-----+---------+---//---+
+//
+// Elements must be valid encodings of type T.
+//
+
+template <typename Key, typename Compare, typename Allocator>
+struct Encoding<std::set<Key, Compare, Allocator>>
+    : EncodingIO<std::set<Key, Compare, Allocator>> {
+  using Type = std::set<Key, Compare, Allocator>;
+
+  static constexpr EncodingByte Prefix(const Type& /*value*/) {
+    return EncodingByte::Array;
+  }
+
+  static constexpr std::size_t Size(const Type& value) {
+    return BaseEncodingSize(Prefix(value)) +
+           Encoding<SizeType>::Size(value.size()) +
+           std::accumulate(value.cbegin(), value.cend(), 0U,
+                           [](const std::size_t& sum, const Key& element) {
+                             return sum + Encoding<Key>::Size(element);
+                           });
+  }
+
+  static constexpr bool Match(EncodingByte prefix) {
+    return prefix == EncodingByte::Array;
+  }
+
+  template <typename Writer>
+  static constexpr Status<void> WritePayload(EncodingByte /*prefix*/,
+                                             const Type& value,
+                                             Writer* writer) {
+    auto status = Encoding<SizeType>::Write(value.size(), writer);
+    if (!status)
+      return status;
+
+    for (const Key& element : value) {
+      status = Encoding<Key>::Write(element, writer);
+      if (!status)
+        return status;
+    }
+
+    return {};
+  }
+
+  template <typename Reader>
+  static constexpr Status<void> ReadPayload(EncodingByte /*prefix*/,
+                                            Type* value, Reader* reader) {
+    SizeType size = 0;
+    auto status = Encoding<SizeType>::Read(&size, reader);
+    if (!status)
+      return status;
+
+    value->clear();
+    for (SizeType i = 0; i < size; i++) {
+      Key element;
+      status = Encoding<Key>::Read(&element, reader);
+      if (!status)
+        return status;
+
+      value->insert(std::move(element));
+    }
+
+    return {};
+  }
+};
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+struct Encoding<std::unordered_set<Key, Hash, KeyEqual, Allocator>>
+    : EncodingIO<std::unordered_set<Key, Hash, KeyEqual, Allocator>> {
+  using Type = std::unordered_set<Key, Hash, KeyEqual, Allocator>;
+
+  static constexpr EncodingByte Prefix(const Type& /*value*/) {
+    return EncodingByte::Array;
+  }
+
+  static constexpr std::size_t Size(const Type& value) {
+    return BaseEncodingSize(Prefix(value)) +
+           Encoding<SizeType>::Size(value.size()) +
+           std::accumulate(value.cbegin(), value.cend(), 0U,
+                           [](const std::size_t& sum, const Key& element) {
+                             return sum + Encoding<Key>::Size(element);
+                           });
+  }
+
+  static constexpr bool Match(EncodingByte prefix) {
+    return prefix == EncodingByte::Array;
+  }
+
+  template <typename Writer>
+  static constexpr Status<void> WritePayload(EncodingByte /*prefix*/,
+                                             const Type& value,
+                                             Writer* writer) {
+    auto status = Encoding<SizeType>::Write(value.size(), writer);
+    if (!status)
+      return status;
+
+    for (const Key& element : value) {
+      status = Encoding<Key>::Write(element, writer);
+      if (!status)
+        return status;
+    }
+
+    return {};
+  }
+
+  template <typename Reader>
+  static constexpr Status<void> ReadPayload(EncodingByte /*prefix*/,
+                                            Type* value, Reader* reader) {
+    SizeType size = 0;
+    auto status = Encoding<SizeType>::Read(&size, reader);
+    if (!status)
+      return status;
+
+    value->clear();
+    for (SizeType i = 0; i < size; i++) {
+      Key element;
+      status = Encoding<Key>::Read(&element, reader);
+      if (!status)
+        return status;
+
+      value->insert(std::move(element));
+    }
+
+    return {};
+  }
+};
+
+}  // namespace nop
+
+#endif  // LIBNOP_INCLUDE_NOP_BASE_SET_H_

--- a/include/nop/serializer.h
+++ b/include/nop/serializer.h
@@ -18,6 +18,7 @@
 #define LIBNOP_INCLUDE_NOP_SERIALIZER_H_
 
 #include <nop/base/array.h>
+#include <nop/base/deque.h>
 #include <nop/base/encoding.h>
 #include <nop/base/enum.h>
 #include <nop/base/handle.h>
@@ -28,6 +29,7 @@
 #include <nop/base/reference_wrapper.h>
 #include <nop/base/result.h>
 #include <nop/base/serializer.h>
+#include <nop/base/set.h>
 #include <nop/base/string.h>
 #include <nop/base/table.h>
 #include <nop/base/tuple.h>


### PR DESCRIPTION
I'm not sure if this repo is maintained anymore, but this PR adds support for the standard library `std::deque`, `std::set`, and `std::unordered_set`. 

I'd also like to add support for some additional types which I frequently use, and I'm wondering if this is something that would also be wanted, such as `std::queue`, `std::priority_queue`, and possibly the standard types for `optional` and `variant`. If so:

1. `std::queue` and `std::priority_queue` do not allow for random access traversal. As such, the only way I can see an implementation for these types is to create a copy and unpeel the copy to access the internal elements. Would this be an acceptable implementation?
2. `std::optional` and `std::variant` require C++17 support. Would this be an issue?

