### PR TITLE
Fix Failures with -D_GLIBCXX_ASSERTIONS

### DIFF
--- a/test/test_reader.h
+++ b/test/test_reader.h
@@ -57,7 +57,7 @@ class TestReader {
     if (length_bytes > (data_.size() - index_))
       return ErrorStatus::ReadLimitReached;
 
-    std::copy(&data_[index_], &data_[index_ + length_bytes], begin_byte);
+    std::copy(&data_[index_], &data_[index_] + length_bytes, begin_byte);
     index_ += length_bytes;
     return {};
   }


### PR DESCRIPTION
Accessing vector elements, even to take the address of, is forbidden if past the end