### PR TITLE
Add missing template args list after the use of the template keyword

### DIFF
--- a/include/nop/rpc/interface.h
+++ b/include/nop/rpc/interface.h
@@ -244,7 +244,7 @@ struct InterfaceMethod {
     template <typename Sender>
     static void Invoke(Sender* sender, Status<Return>* return_value,
                        Args... args) {
-      sender->template SendMethod(InterfaceMethod::Selector, return_value,
+      sender->template SendMethod<>(InterfaceMethod::Selector, return_value,
                                   std::forward_as_tuple(args...));
     }
 

--- a/include/nop/rpc/interface.h
+++ b/include/nop/rpc/interface.h
@@ -245,7 +245,7 @@ struct InterfaceMethod {
     static void Invoke(Sender* sender, Status<Return>* return_value,
                        Args... args) {
       sender->template SendMethod<>(InterfaceMethod::Selector, return_value,
-                                  std::forward_as_tuple(args...));
+                                    std::forward_as_tuple(args...));
     }
 
     // Dispatches the given handler op, getting the arguments from the given

--- a/include/nop/types/variant.h
+++ b/include/nop/types/variant.h
@@ -255,7 +255,8 @@ class Variant {
   // multiple element types.
   template <typename T, typename U>
   void Assign(TypeTag<T>, U&& value) {
-    if (!value_.template Assign<>(TypeTag<T>{}, index_, std::forward<U>(value))) {
+    if (!value_.template Assign<>(TypeTag<T>{}, index_,
+                                  std::forward<U>(value))) {
       Destruct();
       Construct(TypeTag<T>{}, std::forward<U>(value));
     }

--- a/include/nop/types/variant.h
+++ b/include/nop/types/variant.h
@@ -238,7 +238,7 @@ class Variant {
   // resulting type.
   template <typename... Args>
   void Construct(Args&&... args) {
-    index_ = value_.template Construct(std::forward<Args>(args)...);
+    index_ = value_.template Construct<>(std::forward<Args>(args)...);
   }
   void Construct(EmptyVariant) {}
 
@@ -255,14 +255,14 @@ class Variant {
   // multiple element types.
   template <typename T, typename U>
   void Assign(TypeTag<T>, U&& value) {
-    if (!value_.template Assign(TypeTag<T>{}, index_, std::forward<U>(value))) {
+    if (!value_.template Assign<>(TypeTag<T>{}, index_, std::forward<U>(value))) {
       Destruct();
       Construct(TypeTag<T>{}, std::forward<U>(value));
     }
   }
   template <typename T>
   void Assign(T&& value) {
-    if (!value_.template Assign(index_, std::forward<T>(value))) {
+    if (!value_.template Assign<>(index_, std::forward<T>(value))) {
       Destruct();
       Construct(std::forward<T>(value));
     }


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/80801, clang requires an explicit template list after the use of the template keyword for template member function.